### PR TITLE
adding waitFor and io output

### DIFF
--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -5,11 +5,11 @@ bazel_path=$(which bazelisk)
 
 previous_revision="HEAD^"
 final_revision="HEAD"
+output_dir=$(mktemp -d)
 modified_filepaths_output="$PWD/integration/modified_filepaths.txt"
-starting_hashes_json="/tmp/starting_hashes.json"
-final_hashes_json="/tmp/final_hashes_json.json"
-impacted_targets_path="/tmp/impacted_targets.txt"
-impacted_test_targets_path="/tmp/impacted_test_targets.txt"
+starting_hashes_json="$output_dir/starting_hashes.json"
+final_hashes_json="$output_dir/final_hashes_json.json"
+impacted_targets_path="$output_dir/impacted_targets.txt"
 
 export USE_BAZEL_VERSION=last_downstream_green
 
@@ -26,31 +26,26 @@ $bazel_path run :bazel-diff -- generate-hashes -w $workspace_path -b $bazel_path
 
 ruby ./integration/update_final_hashes.rb
 
-$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
-
-$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path -t
+$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 target1="//test/java/com/integration:bazel-diff-integration-test-lib"
 target2="//src/main/java/com/integration:bazel-diff-integration-lib"
 target3="//test/java/com/integration:bazel-diff-integration-tests"
+target4="//src/main/java/com/integration/submodule:Submodule"
 if containsElement $target1 "${impacted_targets[@]}" && \
     containsElement $target2 "${impacted_targets[@]}" && \
     containsElement $target3 "${impacted_targets[@]}"
 then
-    echo "Correct impacted targets"
+    if containsElement $target4 "${impacted_targets[@]}"
+    then
+        echo "Incorrect impacted targets: ${impacted_targets[@]}"
+        exit 1
+    else
+        echo "Correct impacted targets: ${impacted_targets[@]}"
+        exit 0
+    fi
 else
     echo "Incorrect impacted targets: ${impacted_targets[@]}"
-    exit 1
-fi
-
-IFS=$'\n' read -d '' -r -a impacted_test_targets < $impacted_test_targets_path
-target="//test/java/com/integration:bazel-diff-integration-tests"
-if containsElement $target "${impacted_test_targets[@]}";
-then
-    echo "Correct first impacted test target"
-else
-    echo "Impacted test targets: ${impacted_test_targets[@]}"
-    echo "Incorrect first impacted test target: ${target}"
     exit 1
 fi

--- a/integration/modified_filepaths.txt
+++ b/integration/modified_filepaths.txt
@@ -1,2 +1,3 @@
 README.md
 src/main/java/com/integration/StringGenerator.java
+src/main/java/com/integration/submodule/Submodule.java

--- a/integration/src/main/java/com/integration/submodule/BUILD
+++ b/integration/src/main/java/com/integration/submodule/BUILD
@@ -1,10 +1,10 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
 java_library(
-    name = "bazel-diff-integration-lib",
+    name = "Submodule",
     srcs = glob(["*.java"]),
-    deps = [
-        "//src/main/java/com/integration/submodule:Submodule"
+    tags = [
+        "manual"
     ],
     visibility = ["//visibility:public"]
 )

--- a/integration/src/main/java/com/integration/submodule/Submodule.java
+++ b/integration/src/main/java/com/integration/submodule/Submodule.java
@@ -1,0 +1,3 @@
+public class Submodule {
+
+}

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -118,7 +118,6 @@ class BazelClientImpl implements BazelClient {
         cmd.add("--output");
         cmd.add("streamed_proto");
         cmd.add("--order_output=no");
-        cmd.add("--keep-going");
         cmd.add("--show_progress=false");
         cmd.add("--show_loading_progress=false");
         cmd.addAll(this.commandOptions);

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -73,7 +73,7 @@ class BazelClientImpl implements BazelClient {
     @Override
     public Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException, InterruptedException {
         Set<BazelSourceFileTarget> sourceTargets = new HashSet<>();
-        for (List<Path> partition : Iterables.partition(filepaths, 1)) {
+        for (List<Path> partition : Iterables.partition(filepaths, 100)) {
             String targetQuery = partition
                     .stream()
                     .map(path -> path.toString())
@@ -116,7 +116,7 @@ class BazelClientImpl implements BazelClient {
         cmd.add("--query_file");
         cmd.add(tempFile.toString());
 
-        ProcessBuilder pb = new ProcessBuilder(cmd).inheritIO().directory(workingDirectory.toFile());
+        ProcessBuilder pb = new ProcessBuilder(cmd).directory(workingDirectory.toFile());
 
         Process process = pb.start();
         ArrayList<Build.Target> targets = new ArrayList<>();

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -127,7 +127,6 @@ class BazelClientImpl implements BazelClient {
         cmd.add("query");
         cmd.add("--output");
         cmd.add("streamed_proto");
-        cmd.add("--keep_going");
         cmd.add("--order_output=no");
         cmd.add("--show_progress=false");
         cmd.add("--show_loading_progress=false");

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -118,6 +118,7 @@ class BazelClientImpl implements BazelClient {
         cmd.add("--output");
         cmd.add("streamed_proto");
         cmd.add("--order_output=no");
+        cmd.add("--keep-going");
         cmd.add("--show_progress=false");
         cmd.add("--show_loading_progress=false");
         cmd.addAll(this.commandOptions);

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -19,10 +19,10 @@ import java.util.stream.Collectors;
 import java.util.Arrays;
 
 interface BazelClient {
-    List<BazelTarget> queryAllTargets() throws IOException, InterruptedException;
-    Set<String> queryForImpactedTargets(Set<String> impactedTargets) throws IOException, InterruptedException;
-    Set<String> queryForTestTargets(Set<String> targets) throws IOException, InterruptedException;
-    Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException, InterruptedException;
+    List<BazelTarget> queryAllTargets() throws IOException;
+    Set<String> queryForImpactedTargets(Set<String> impactedTargets) throws IOException;
+    Set<String> queryForTestTargets(Set<String> targets) throws IOException;
+    Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException;
 }
 
 class BazelClientImpl implements BazelClient {
@@ -39,13 +39,13 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public List<BazelTarget> queryAllTargets() throws IOException, InterruptedException {
+    public List<BazelTarget> queryAllTargets() throws IOException {
         List<Build.Target> targets = performBazelQuery("'//external:all-targets' + '//...:all-targets'");
         return targets.stream().map( target -> new BazelTargetImpl(target)).collect(Collectors.toList());
     }
 
     @Override
-    public Set<String> queryForImpactedTargets(Set<String> impactedTargets) throws IOException, InterruptedException {
+    public Set<String> queryForImpactedTargets(Set<String> impactedTargets) throws IOException {
         Set<String> impactedTestTargets = new HashSet<>();
         String targetQuery = impactedTargets.stream().collect(Collectors.joining(" + "));
         List<Build.Target> targets = performBazelQuery(String.format("rdeps(//..., %s)", targetQuery));
@@ -58,7 +58,7 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public Set<String> queryForTestTargets(Set<String> targets) throws IOException, InterruptedException {
+    public Set<String> queryForTestTargets(Set<String> targets) throws IOException {
         Set<String> impactedTestTargets = new HashSet<>();
         String targetQuery = targets.stream().collect(Collectors.joining(" + "));
         List<Build.Target> testTargets = performBazelQuery(String.format("kind(test, %s)", targetQuery));
@@ -71,9 +71,9 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException, InterruptedException {
+    public Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException {
         Set<BazelSourceFileTarget> sourceTargets = new HashSet<>();
-        for (List<Path> partition : Iterables.partition(filepaths, 100)) {
+        for (List<Path> partition : Iterables.partition(filepaths, 1)) {
             String targetQuery = partition
                     .stream()
                     .map(path -> path.toString())
@@ -98,7 +98,7 @@ class BazelClientImpl implements BazelClient {
         return sourceTargets;
     }
 
-    private List<Build.Target> performBazelQuery(String query) throws IOException, InterruptedException {
+    private List<Build.Target> performBazelQuery(String query) throws IOException {
         Path tempFile = Files.createTempFile(null, ".txt");
         Files.write(tempFile, query.getBytes(StandardCharsets.UTF_8));
 
@@ -109,7 +109,6 @@ class BazelClientImpl implements BazelClient {
         cmd.add("--output");
         cmd.add("streamed_proto");
         cmd.add("--order_output=no");
-        cmd.add("--keep_going");
         cmd.add("--show_progress=false");
         cmd.add("--show_loading_progress=false");
         cmd.addAll(this.commandOptions);
@@ -117,7 +116,6 @@ class BazelClientImpl implements BazelClient {
         cmd.add(tempFile.toString());
 
         ProcessBuilder pb = new ProcessBuilder(cmd).directory(workingDirectory.toFile());
-
         Process process = pb.start();
         ArrayList<Build.Target> targets = new ArrayList<>();
         while (true) {
@@ -125,7 +123,6 @@ class BazelClientImpl implements BazelClient {
             if (target == null) break;  // EOF
             targets.add(target);
         }
-        process.waitFor();
 
         Files.delete(tempFile);
 

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -7,9 +7,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 interface TargetHashingClient {
-    Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException, InterruptedException;
-    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException;
-    Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException;
+    Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException;
+    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException;
+    Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException;
 }
 
 class TargetHashingClientImpl implements TargetHashingClient {
@@ -20,7 +20,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException, InterruptedException {
+    public Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException {
         Set<BazelSourceFileTarget> bazelSourcefileTargets = bazelClient.convertFilepathsToSourceTargets(modifiedFilepaths);
         List<BazelTarget> allTargets = bazelClient.queryAllTargets();
         Map<String, String> targetHashes = new HashMap<>();
@@ -52,7 +52,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException {
+    public Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException {
         Set<String> impactedTargets = new HashSet<>();
         for ( Map.Entry<String,String> entry : endHashes.entrySet()) {
             String startHashValue = startHashes.get(entry.getKey());
@@ -64,7 +64,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException {
+    public Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException {
         Set<String> impactedTargets = getImpactedTargets(startHashes, endHashes);
         return bazelClient.queryForTestTargets(impactedTargets);
     }

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -7,9 +7,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 interface TargetHashingClient {
-    Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException;
-    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException;
-    Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException;
+    Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException, InterruptedException;
+    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException;
+    Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException;
 }
 
 class TargetHashingClientImpl implements TargetHashingClient {
@@ -20,7 +20,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException {
+    public Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException, InterruptedException {
         Set<BazelSourceFileTarget> bazelSourcefileTargets = bazelClient.convertFilepathsToSourceTargets(modifiedFilepaths);
         List<BazelTarget> allTargets = bazelClient.queryAllTargets();
         Map<String, String> targetHashes = new HashMap<>();
@@ -52,7 +52,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException {
+    public Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException {
         Set<String> impactedTargets = new HashSet<>();
         for ( Map.Entry<String,String> entry : endHashes.entrySet()) {
             String startHashValue = startHashes.get(entry.getKey());
@@ -64,7 +64,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException {
+    public Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException, InterruptedException {
         Set<String> impactedTargets = getImpactedTargets(startHashes, endHashes);
         return bazelClient.queryForTestTargets(impactedTargets);
     }

--- a/src/main/java/com/bazel_diff/VersionProvider.java
+++ b/src/main/java/com/bazel_diff/VersionProvider.java
@@ -5,7 +5,7 @@ import picocli.CommandLine.IVersionProvider;
 class VersionProvider implements IVersionProvider {
     public String[] getVersion() throws Exception {
         return new String[] {
-            "1.2.1"
+            "2.0.0"
         };
     }
 }

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -141,8 +141,8 @@ class BazelDiff implements Callable<Integer> {
     @Option(names = {"-o", "--output"}, scope = ScopeType.LOCAL, description = "Filepath to write the impacted Bazel targets to, newline separated")
     File outputPath;
 
-    @Option(names = {"-t", "--tests"}, scope = ScopeType.LOCAL, description = "Return only targets of kind 'test'")
-    boolean testTargets;
+    @Option(names = {"-aq", "--avoid-query"}, scope = ScopeType.LOCAL, description = "A Bazel query string, any targets that pass this query will be removed from the returned set of targets")
+    String avoidQuery;
 
     @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional space separated Bazel client startup options used when invoking Bazel", scope = ScopeType.INHERIT)
     String bazelStartupOptions;
@@ -190,12 +190,7 @@ class BazelDiff implements Callable<Integer> {
         Map<String, String > gsonHash = new HashMap<>();
         Map<String, String> startingHashes = gson.fromJson(startingFileReader, gsonHash.getClass());
         Map<String, String> finalHashes = gson.fromJson(finalFileReader, gsonHash.getClass());
-        Set<String> impactedTargets;
-        if (testTargets) {
-            impactedTargets = hashingClient.getImpactedTestTargets(startingHashes, finalHashes);
-        } else {
-            impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes);
-        }
+        Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes, avoidQuery);
         try {
             FileWriter myWriter = new FileWriter(outputPath);
             myWriter.write(impactedTargets.stream().collect(Collectors.joining(System.lineSeparator())));

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -151,7 +151,7 @@ class BazelDiff implements Callable<Integer> {
     String bazelCommandOptions;
 
     @Override
-    public Integer call() throws IOException, InterruptedException {
+    public Integer call() throws IOException {
         if (startingHashesJSONPath == null || !startingHashesJSONPath.canRead()) {
             System.out.println("startingHashesJSONPath does not exist! Exiting");
             return ExitCode.USAGE;

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -151,7 +151,7 @@ class BazelDiff implements Callable<Integer> {
     String bazelCommandOptions;
 
     @Override
-    public Integer call() throws IOException {
+    public Integer call() throws IOException, InterruptedException {
         if (startingHashesJSONPath == null || !startingHashesJSONPath.canRead()) {
             System.out.println("startingHashesJSONPath does not exist! Exiting");
             return ExitCode.USAGE;

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -115,7 +115,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet())).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1", "rule3"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -126,7 +126,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         expectedSet.add("rule3");
@@ -134,9 +134,9 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void getImpactedTestTargets() throws IOException {
-        when(bazelClientMock.queryForTestTargets(anySet())).thenReturn(
-                new HashSet<>(Arrays.asList("rule1test", "rule3test", "someothertest"))
+    public void getImpactedTargets_withAvoidQuery() throws IOException {
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
+                new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
         Map<String, String> hash1 = new HashMap<>();
@@ -146,12 +146,10 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set <String> impactedTestTargets = client.getImpactedTestTargets(hash1, hash2);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query");
         Set<String> expectedSet = new HashSet<>();
-        expectedSet.add("rule1test");
-        expectedSet.add("someothertest");
-        expectedSet.add("rule3test");
-        assertEquals(expectedSet, impactedTestTargets);
+        expectedSet.add("rule1");
+        assertEquals(expectedSet, impactedTargets);
     }
 
     private BazelTarget createRuleTarget(String ruleName, List<String> ruleInputs, String ruleDigest) throws NoSuchAlgorithmException {


### PR DESCRIPTION
Generating hashes for a large json changeset (~1000 files) takes around 1hr. However on our similar setup it takes a minute. This PR adds some output and thread safety to the bazel query.